### PR TITLE
ENH: time now recorded only for running core in benchmarkable

### DIFF
--- a/src/benchmarkable.jl
+++ b/src/benchmarkable.jl
@@ -37,12 +37,15 @@ macro benchmarkable(name, setup, core, teardown)
             for _ in 1:n_samples
                 # Store pre-evaluation state information
                 stats = Base.gc_num()
-                elapsed_time = time_ns()
+                time_before = time_ns()
 
                 # Evaluate the core expression n_evals times.
                 for _ in 1:n_evals
                     out = $(esc(core))
                 end
+
+                # get time before comparing GC info
+                elapsed_time = time_ns() - time_before
 
                 # Compare post-evaluation state with pre-evaluation state.
                 diff = Base.GC_Diff(Base.gc_num(), stats)
@@ -51,7 +54,7 @@ macro benchmarkable(name, setup, core, teardown)
 
                 # Append data for this sample to the Samples objects.
                 push!(s.n_evals, n_evals)
-                push!(s.elapsed_times, time_ns() - elapsed_time)
+                push!(s.elapsed_times, elapsed_time)
                 push!(s.bytes_allocated, bytes)
                 push!(s.gc_times, diff.total_time)
                 push!(s.num_allocations, allocs)

--- a/src/execute.jl
+++ b/src/execute.jl
@@ -115,12 +115,15 @@ function execute(
     # evaluate the core expression per sample, we perform a geometric search
     # that starts at 2 evaluations per sample and increases by a factor of 1.1
     # evaluations on each iteration. Having generated data in this form, we
-    # use an OLD regression to estimate the per-evaluation timing of our core
+    # use an OLS regression to estimate the per-evaluation timing of our core
     # expression. We stop our geometric search when the OLS linear model is
     # almost perfect fit to our empirical data.
 
     # We start by executing two evaluations per sample.
     n_evals = 2.0
+
+    # print header about the search progress
+    verbose && @printf "%s\t%20s\t%8s\t%s\n" "time_used" "n_evals" "b" "r²"
 
     # Now we perform a geometric search.
     finished = false


### PR DESCRIPTION
Minor change to record time for execution immediately after running `core` instead of after computing/`push!`ing GC stats.
