### PR TITLE
Use gensymed const bindings

### DIFF
--- a/src/benchmarkable.jl
+++ b/src/benchmarkable.jl
@@ -30,7 +30,11 @@
 # recursively add non-constant symbols in module m to a list
 find_nonconsts(m, x::Any, list) = list
 find_nonconsts(m, s::Symbol, list) = isconst(m, s) ? list : push!(list, s)
-find_nonconsts(m, e::Expr, list) = (map(a->find_nonconsts(m,a,list), e.args); list)
+function find_nonconsts(m, e::Expr, list)
+    e.head == :line && return # skip line nodes
+    map(a->find_nonconsts(m,a,list), e.args)
+    list
+end
 
 macro benchmarkable(name, setup, core, teardown)
     inner = gensym(:inner)


### PR DESCRIPTION
This seems to be a much more sane way to do things here.  As far as I can tell, `@benchmark` from the global scope is working exactly as it was before.

However, there are still some strange effects in local scopes.  I believe we're hitting a known Julia performance issue with functions inside let scopes, but I can't find a reference to it now.

```
julia> x = 10
10

julia> @benchmark x*x
================ Benchmark Results ========================
     Time per evaluation: 3.04 ns [3.03 ns, 3.06 ns]
Proportion of time in GC: 0.00% [0.00%, 0.00%]
        Memory allocated: 0.00 bytes
   Number of allocations: 0 allocations
       Number of samples: 11801
   Number of evaluations: 153241801
         R² of OLS model: 0.991
 Time spent benchmarking: 0.54 s

julia> let
       x = 10
       @benchmark x*x
       end
================ Benchmark Results ========================
     Time per evaluation: 30.96 ns [30.54 ns, 31.39 ns]
Proportion of time in GC: 0.00% [0.00%, 0.00%]
        Memory allocated: 0.00 bytes
   Number of allocations: 0 allocations
       Number of samples: 9401
   Number of evaluations: 15560101
         R² of OLS model: 0.953
 Time spent benchmarking: 0.55 s
```
