### PR TITLE
Allow functions with keyword arguments

### DIFF
--- a/src/benchmarkable.jl
+++ b/src/benchmarkable.jl
@@ -28,8 +28,13 @@
 #         evaluated per sample.
 
 macro benchmarkable(name, setup, core, teardown)
-    expr = core
-    # only support function calls
+    # We only support function calls to be passed in `core`, but some syntaxes
+    # have special parsing that will lower to a function call upon expansion
+    # (e.g., A[i] or user macros). The tricky thing is that keyword functions
+    # *also* have a special lowering step that we don't want (they are harder to
+    # work with and would obscure some of the overhead of keyword arguments). So
+    # we only expand the passed expression if it is not already a function call.
+    expr = (core.head == :call) ? core : expand(core)
     expr.head == :call || throw(ArgumentError("expression to benchmark must be a function call"))
     f = expr.args[1]
     fargs = expr.args[2:end]

--- a/test/04_api.jl
+++ b/test/04_api.jl
@@ -1,0 +1,22 @@
+# Ensure that the `@benchmark` user-facing API supports the following cases:
+using Benchmarks
+# no-op function calls:
+f() = nothing
+@benchmark f()
+
+# infix operators
+@benchmark (3.0+5im)^3.2
+
+# indexing
+A = rand(2,2)
+@benchmark A[end,end]
+
+# Keyword arguments
+@benchmark svds(A, nsv=1)
+
+# local scopes
+x = 1
+let B = copy(A), y = 2
+    @benchmark B[1]
+    @benchmark x+y
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ my_tests = [
     "01_clock_resolution.jl",
     "02_environment.jl",
     "03_samples.jl",
+    "04_api.jl",
 ]
 
 println("Running tests:")


### PR DESCRIPTION
Unfortunately this fix breaks benchmarking indexing assignments because calling `expand` on a keyword function call does all sorts of crazy things to the AST.  I suppose we _could_ handle it, but it is really messy. I suppose I'm okay giving up `@benchmark A[I]`.

Fixes #32.
