### PR TITLE
Make estimate_clock_resolution more robust

### DIFF
--- a/src/01_clock_resolution.jl
+++ b/src/01_clock_resolution.jl
@@ -21,6 +21,10 @@ function estimate_clock_resolution(n_samples::Integer = 10_000)
     for _ in 1:n_samples
         t1 = Base.time_ns()
         t2 = Base.time_ns()
+        # On Linux AArch64 it seems that t1 and t2 could be the same sometimes
+        while t2 <= t1
+            t2 = Base.time_ns()
+        end
         Δt = t2 - t1
         min_Δt = min(min_Δt, Δt)
     end


### PR DESCRIPTION
By checking for zero time interval.

This seems to happen on AArch64 Linux and doesn't seem to be legal.

Fixes `Benchmarks.jl` randomly returning wierd values issue on AArch64 Linux (or at least the board I tested on).
