### PR TITLE
run garbage collector before running a benchmark

### DIFF
--- a/src/benchmarkable.jl
+++ b/src/benchmarkable.jl
@@ -89,6 +89,7 @@ macro benchmarkable(name, setup, core, teardown)
                 n_samples::Integer,
                 evaluations::Integer,
             )
+            gc()
             $(benchfn)(s, n_samples, evaluations, $(map(esc, userargs)...))
         end
         function $(benchfn)(


### PR DESCRIPTION
My thinking is that if we are close to a garbage collection when we start a new benchmark this means that allocations that happened outside the benchmark leaks into the benchmark results. By explicitly calling `gc()` from the most outer function we should start with a "clean slate".
