### PR TITLE
Allow semicolon-separated kwargs in function calls

### DIFF
--- a/src/benchmarkable.jl
+++ b/src/benchmarkable.jl
@@ -37,7 +37,7 @@ macro benchmarkable(name, setup, core, teardown)
     expr = (core.head == :call) ? core : expand(core)
     expr.head == :call || throw(ArgumentError("expression to benchmark must be a function call"))
     f = expr.args[1]
-    fargs = expr.args[2:end]
+    fargs = flatten_parameters(expr.args[2:end])
     nargs = length(expr.args)-1
 
     # Pull out the arguments -- both positional and keywords
@@ -138,4 +138,16 @@ macro benchmarkable(name, setup, core, teardown)
         # "return" the outermost entry point as the final expression
         $(esc(name))
     end
+end
+
+# take a list of arguments and return the list with any parameter kwargs
+# extracted and appended to the rest of the original arguments
+function flatten_parameters(fargs)
+    if !(isempty(fargs))
+        arg1 = first(fargs)
+        if isa(arg1, Expr) && arg1.head == :parameters
+            return [drop(fargs, 1)..., arg1.args...]
+        end
+    end
+    return fargs
 end


### PR DESCRIPTION
This fix from my fork seems to port over cleanly to here, and resolves #32, so I figured I'd open a PR. 

Before this PR:

``` julia
julia> @benchmark svds(rand(2,2); nsv = 1)
ERROR: error compiling ##7129: unsupported or misplaced expression "parameters" in function ##7129
 in execute at /Users/jarrettrevels/.julia/v0.4/Benchmarks/src/execute.jl:47
 in execute at /Users/jarrettrevels/.julia/v0.4/Benchmarks/src/execute.jl:42
```

After this PR: 

``` julia
julia> @benchmark svds(rand(2,2); nsv = 1)
================ Benchmark Results ========================
     Time per evaluation: 113.67 μs [44.04 μs, 183.29 μs]
Proportion of time in GC: 0.00% [0.00%, 0.00%]
        Memory allocated: 9.63 kb
   Number of allocations: 170 allocations
       Number of samples: 100
   Number of evaluations: 100
 Time spent benchmarking: 1.90 s
```
