### PR TITLE
Fix 0.5 support

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,0 +1,2 @@
+julia 0.4
+Compat 0.7.14+

--- a/src/02_environment.jl
+++ b/src/02_environment.jl
@@ -3,38 +3,38 @@
 #
 # Fields:
 #
-#     uuid::UTF8String: A random UUID that uniquely identifies each run.
+#     uuid::String: A random UUID that uniquely identifies each run.
 #
-#     timestamp::UTF8String: The time when we began executing benchmarks.
+#     timestamp::String: The time when we began executing benchmarks.
 #
-#     julia_sha1::UTF8String: The SHA1 for the Julia Git revision we're working
+#     julia_sha1::String: The SHA1 for the Julia Git revision we're working
 #         from.
 #
-#     package_sha1::Nullable{UTF8String}: The SHA1 for the current repo's Git
+#     package_sha1::Nullable{String}: The SHA1 for the current repo's Git
 #         revision (if any). This field is null when the code was not executed
 #         inside of a Git repo.
 #
-#     os::UTF8String: The OS we're running on.
+#     os::String: The OS we're running on.
 #
 #     cpu_cores::Int: The number of CPU cores available.
 #
-#     arch::UTF8String: The architecture we're running on.
+#     arch::String: The architecture we're running on.
 #
-#     machine::UTF8String: The machine type we're running on.
+#     machine::String: The machine type we're running on.
 #
 #     use_blas64::Bool: Was BLAS configured to use 64-bits?
 #
 #     word_size::Int: The word size of the host machine.
 
 immutable Environment
-    uuid::UTF8String
-    timestamp::UTF8String
-    julia_sha1::UTF8String
-    package_sha1::Nullable{UTF8String}
-    os::UTF8String
+    uuid::Compat.String
+    timestamp::Compat.String
+    julia_sha1::Compat.String
+    package_sha1::Nullable{Compat.String}
+    os::Compat.String
     cpu_cores::Int
-    arch::UTF8String
-    machine::UTF8String
+    arch::Compat.String
+    machine::Compat.String
     use_blas64::Bool
     word_size::Int
 
@@ -42,10 +42,10 @@ immutable Environment
         uuid = string(Base.Random.uuid4())
         timestamp = Libc.strftime("%Y-%m-%d %H:%M:%S", round(Int, time()))
         julia_sha1 = Base.GIT_VERSION_INFO.commit
-        package_sha1 = Nullable{UTF8String}()
+        package_sha1 = Nullable{Compat.String}()
         try
             sha1 = readchomp(pipeline(`git rev-parse HEAD`, stderr=Base.DevNull))
-            package_sha1 = Nullable{UTF8String}(utf8(sha1))
+            package_sha1 = Nullable{Compat.String}(utf8(sha1))
         end
         os = string(OS_NAME)
         cpu_cores = CPU_CORES
@@ -79,7 +79,7 @@ end
 #     e::Environment: The `Environment` object that we want to print to `io`.
 
 function Base.show(io::IO, e::Environment)
-    names = UTF8String[
+    names = Compat.String[
         "UUID",
         "Time",
         "Julia SHA1",
@@ -125,7 +125,7 @@ end
 #         Defaults to false.
 
 function Base.writecsv(filename::AbstractString, e::Environment, append::Bool = false)
-    names = UTF8String[
+    names = Compat.String[
         "uuid",
         "timestamp",
         "julia_sha1",

--- a/src/03_samples.jl
+++ b/src/03_samples.jl
@@ -103,7 +103,7 @@ end
 #     s::Samples: The `Samples` object that we want to print to `io`.
 
 function Base.show(io::IO, s::Samples)
-    names = UTF8String["Number of samples"]
+    names = Compat.String["Number of samples"]
     values = Any[length(s.elapsed_times)]
 
     @printf(io, "================== Benchmark Samples ======================\n")

--- a/src/Benchmarks.jl
+++ b/src/Benchmarks.jl
@@ -1,4 +1,7 @@
 module Benchmarks
+
+    using Compat
+
     export @benchmark
 
     include("01_clock_resolution.jl")

--- a/src/benchmarkable.jl
+++ b/src/benchmarkable.jl
@@ -109,7 +109,7 @@ macro benchmarkable(name, setup, core, teardown)
 
                 # Evaluate the core expression n_evals times.
                 for _ in 1:evaluations
-                    out = $(innerfn)($(args...))
+                    out = $(esc(innerfn))($(args...))
                 end
 
                 # get time before comparing GC info
@@ -131,9 +131,9 @@ macro benchmarkable(name, setup, core, teardown)
             # The caller receives all data via the mutated Results object.
             return
         end
-        @noinline function $(innerfn)($(map(esc, args)...))
-            $(esc(f))($(map(esc, posargs)...), $(map(esc, kws)...))
-        end
+        $(esc(:(@noinline function $innerfn($(args...))
+            $f($(posargs...), $(kws...))
+        end)))
 
         # "return" the outermost entry point as the final expression
         $(esc(name))

--- a/src/wrapper_types.jl
+++ b/src/wrapper_types.jl
@@ -3,12 +3,12 @@
 #
 # Fields:
 #
-#    name::UTF8String: The name of the benchmark.
+#    name::String: The name of the benchmark.
 #
 #    f!::Function: A function that implements the "benchmarkable" protocol.
 
 immutable Benchmark
-    name::UTF8String
+    name::Compat.String
     f!::Function
 end
 
@@ -16,11 +16,11 @@ end
 #
 # Fields:
 #
-#     name::UTF8String: The name of the suite of benchmarks.
+#     name::String: The name of the suite of benchmarks.
 #
 #     benchmarks::Vector{Benchmark}: A vector of the benchmarks in the suite.
 
 immutable BenchmarkSuite
-    name::UTF8String
+    name::Compat.String
     benchmarks::Vector{Benchmark}
 end

--- a/test/02_environment.jl
+++ b/test/02_environment.jl
@@ -1,6 +1,7 @@
 module TestEnvironment
     import Benchmarks
     using Base.Test
+    using Compat
 
     e = Benchmarks.Environment()
 
@@ -9,6 +10,6 @@ module TestEnvironment
 
     path = tempname()
     writecsv(path, e)
-    bytes = readall(path)
+    bytes = readstring(path)
     rm(path)
 end

--- a/test/03_samples.jl
+++ b/test/03_samples.jl
@@ -1,6 +1,7 @@
 module TestSamples
     import Benchmarks
     using Base.Test
+    using Compat
 
     s = Benchmarks.Samples()
 
@@ -11,7 +12,7 @@ module TestSamples
 
     path = tempname()
     writecsv(path, s)
-    bytes = readall(path)
+    bytes = readstring(path)
     rm(path)
 
     empty!(s)


### PR DESCRIPTION
- Depwarn for `readall`
- Depwarn for `UTF8String`
- Workaround error when using `esc` on function argument. Ref https://github.com/JuliaLang/julia/issues/16096#issuecomment-216442791 Fixes https://github.com/johnmyleswhite/Benchmarks.jl/issues/45
- Add Compat 0.7.14+ dependency
