### PR TITLE
Fix Compat for julia 0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.7.14+
+Compat 0.7.14 0.8-


### PR DESCRIPTION
I'm not sure what is meant in the last change but adding a `+` to the end of a version number isn't documented and seems to cause issues on 0.4:

```
ERROR: fixed packages introduce conflicting requirements for Compat: 
         Benchmarks requires versions [0.7.14+,∞) [none of the available versions can satisfy this requirement]
       available versions are 0.0.1, 0.0.2, 0.1.0, 0.1.1, 0.2.0, 0.2.1, 0.2.2, 0.2.3, 0.2.4, 0.2.5, 0.2.6, 0.2.7, 0.2.8, 0.2.9, 0.2.10, 0.2.11, 0.2.12, 0.2.13, 0.3.0, 0.3.1, 0.3.2, 0.3.3, 0.3.4, 0.3.5, 0.3.6, 0.3.7, 0.3.8, 0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4, 0.4.5, 0.4.6, 0.4.7, 0.4.8, 0.4.9, 0.4.10, 0.4.11, 0.4.12, 0.4.13, 0.5.0, 0.5.1, 0.6.0, 0.7.0, 0.7.1, 0.7.2, 0.7.3, 0.7.4, 0.7.5, 0.7.6, 0.7.7, 0.7.8, 0.7.9, 0.7.10, 0.7.11, 0.7.12, 0.7.13 and 0.7.14
```

If what `0.7.14+` means to accept any version above that then maybe it should be `Compat 0.7.14 0.8-` which I think would accept from 0.7.14 up to (and not including) a 0.8 pre-release.
